### PR TITLE
Remove the required parameter from `@JsonRpcParam`

### DIFF
--- a/core/src/main/java/com/github/arteam/simplejsonrpc/core/annotation/JsonRpcParam.java
+++ b/core/src/main/java/com/github/arteam/simplejsonrpc/core/annotation/JsonRpcParam.java
@@ -29,14 +29,4 @@ public @interface JsonRpcParam {
      * @return parameter name
      */
     public String value();
-
-    /**
-     * Whether parameter is required
-     *
-     * If {@code false}, it means that a client isn't forced to pass this parameter to the method.
-     * If the client doesn't provide the parameter, {@code null} value is used for complex types
-     * and an appropriate default value for primitives.
-     * @return whether parameter is required
-     */
-    public boolean required() default true;
 }


### PR DESCRIPTION
We use the `@JsonRpcOptional` annotation for marking things as optional and this parameter is just a leftover from the previous implementation.

Fixes #3 