### PR TITLE
Updated README.md to point to latest release

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -99,7 +99,7 @@ Maven:
 <dependency>
    <groupId>com.github.arteam</groupId>
    <artifactId>simple-json-rpc-server</artifactId>
-   <version>0.5</version>
+   <version>0.9</version>
 </dependency>
 ```
 


### PR DESCRIPTION
The example setup for Maven mentioned in the README now points to the latest release.