### PR TITLE
Feature ServiceResolver

### DIFF
--- a/server/src/main/java/com/github/arteam/simplejsonrpc/server/JsonRpcServer.java
+++ b/server/src/main/java/com/github/arteam/simplejsonrpc/server/JsonRpcServer.java
@@ -74,6 +74,33 @@ public class JsonRpcServer {
     private final ConcurrentMap<Class<? extends Throwable>, ErrorDataResolver> dataResolvers = new ConcurrentHashMap<>();
 
     /**
+     * Generic service resolver interface
+     */
+    public static interface ServiceResolver {
+        
+        /**
+         * Resolve service by string
+         * @param serviceAddress
+         * @return the service or null if no service is present.
+         */
+        Object getService(String serviceAddress);
+
+        /**
+         * Extract the method part of a request given method.
+         * @param method from request
+         * @return resulting method for service call
+         */
+        String extractMethod(String method);
+
+        /**
+         * Extract the service addressing part of a request given method
+         * @param method from service
+         * @return resulting identifier for service resolvin for this ServiceResplver
+         */
+        String extractServiceAddress(String method);
+    }
+    
+    /**
      * Init JSON-RPC server
      *
      * @param mapper used-defined JSON mapper
@@ -186,6 +213,18 @@ public class JsonRpcServer {
             return ErrorResponse.of(INVALID_REQUEST);
         }
 
+        //Check if we have a scoped service address and need to resolve the service
+        if (service instanceof ServiceResolver serviceResolver) {
+            String requestMethod = request.method();
+            Object addressedService = serviceResolver.getService(serviceResolver.extractServiceAddress(requestMethod));
+            if (null == addressedService) {
+                log.warn(requestMethod + " is not available as a JSON-RPC 2.0 service");
+                return ErrorResponse.of(request.id(), METHOD_NOT_FOUND);
+            }
+            service = addressedService;
+            request = new Request(request.jsonrpc(), serviceResolver.extractMethod(request.method()), request.params(), request.id());
+        }
+        
         try {
             return handleSingle(request, service);
         } catch (Exception e) {

--- a/server/src/test/java/com/github/arteam/simplejsonrpc/server/serviceresolver/DefaultServiceResolver.java
+++ b/server/src/test/java/com/github/arteam/simplejsonrpc/server/serviceresolver/DefaultServiceResolver.java
@@ -1,26 +1,3 @@
-/*
- * The MIT License
- *
- * Copyright 2025 Joerg.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
 package com.github.arteam.simplejsonrpc.server.serviceresolver;
 
 import com.github.arteam.simplejsonrpc.server.JsonRpcServer;

--- a/server/src/test/java/com/github/arteam/simplejsonrpc/server/serviceresolver/DefaultServiceResolver.java
+++ b/server/src/test/java/com/github/arteam/simplejsonrpc/server/serviceresolver/DefaultServiceResolver.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2025 Joerg.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.github.arteam.simplejsonrpc.server.serviceresolver;
+
+import com.github.arteam.simplejsonrpc.server.JsonRpcServer;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * JSON-RPC service resolver for multiple services encoded in
+ * JSON request method name.
+ * Expect naming "service.method" dot separated string with only one
+ * dot service name depth.
+ */
+public class DefaultServiceResolver implements JsonRpcServer.ServiceResolver {
+
+    private final Map<String, Object> services = new HashMap<>();
+    
+    /**
+     * Return resolved service object to given service address.
+     * This implementation works on simple string mapping.
+     * @param serviceAddress extracted from request method.
+     * @return service object, or null if service is not known
+     */
+    @Override
+    public Object getService(String serviceAddress) {
+        return services.get(serviceAddress);
+    }
+
+    /**
+     * Register a service object with given serviceAddress
+     * @param serviceAddress for registering the service
+     * @param service object to be registered
+     * @return this for fluent usage
+     */
+    public DefaultServiceResolver add(String serviceAddress, Object service) {
+        services.put(serviceAddress, service);
+        return this;
+    }
+    
+    @Override
+    public String extractMethod(String method) {
+        //expect "service.method", dot separated string with only one dot.
+        int lastIndexOfDot = method.lastIndexOf('.');
+        if (-1 != lastIndexOfDot) {
+            return method.substring(lastIndexOfDot + 1);
+        } else {
+            return method;
+        }
+    }
+
+    @Override
+    public String extractServiceAddress(String method) {
+        //expect "service.method", dot separated string with only one dot.
+        int lastIndexOfDot = method.lastIndexOf('.');
+        if (-1 != lastIndexOfDot) {
+            return method.substring(0, lastIndexOfDot);
+        } else {
+            return null;
+        }
+    }
+    
+}

--- a/server/src/test/java/com/github/arteam/simplejsonrpc/server/serviceresolver/JsonRpcServiceResolverTest.java
+++ b/server/src/test/java/com/github/arteam/simplejsonrpc/server/serviceresolver/JsonRpcServiceResolverTest.java
@@ -20,9 +20,8 @@ import java.util.Properties;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Date: 7/28/14
- * Time: 10:29 PM
  * Tests typical patterns of a JSON-RPC interaction
+ * JsonRpcServiceResolverTest in combination with SpecTest
  */
 public class JsonRpcServiceResolverTest {
 

--- a/server/src/test/java/com/github/arteam/simplejsonrpc/server/serviceresolver/JsonRpcServiceResolverTest.java
+++ b/server/src/test/java/com/github/arteam/simplejsonrpc/server/serviceresolver/JsonRpcServiceResolverTest.java
@@ -1,0 +1,277 @@
+package com.github.arteam.simplejsonrpc.server.serviceresolver;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.github.arteam.simplejsonrpc.server.JsonRpcServer;
+import com.github.arteam.simplejsonrpc.server.simple.service.TeamService;
+import com.github.arteam.simplejsonrpc.server.simple.util.RequestResponse;
+import com.github.arteam.simplejsonrpc.server.spec.CalculatorService;
+import com.github.arteam.simplejsonrpc.server.spec.SpecTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+import java.util.Properties;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Date: 7/28/14
+ * Time: 10:29 PM
+ * Tests typical patterns of a JSON-RPC interaction
+ */
+public class JsonRpcServiceResolverTest {
+
+    private static final ObjectMapper userMapper = new ObjectMapper()
+            .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+            .registerModule(new Jdk8Module());
+    private static final JsonRpcServer rpcServer = new JsonRpcServer(userMapper);
+    
+    private static final DefaultServiceResolver serviceResolver = new DefaultServiceResolver()
+            .add("teamService", new TeamService())
+            .add("calculatorService", new CalculatorService());
+
+    private static Map<String, RequestResponse> testData;
+
+    @BeforeAll
+    public static void init() throws Exception {
+        try (var is = requireNonNull(JsonRpcServiceResolverTest.class.getResourceAsStream("/test_data.json"))) {
+            testData = userMapper.readValue(is.readAllBytes(), new TypeReference<>() {
+            });
+        }
+    }
+
+    /**
+     * Tests adding of a complex object
+     */
+    @Test
+    public void testAddPlayer() {
+        test("add_player");
+        test("find_shattenkirk");
+    }
+
+    /**
+     * Tests usual case (request and complex response)
+     */
+    @Test
+    public void testFindPlayer() {
+        test("find_player");
+    }
+
+    /**
+     * Tests null as a result
+     */
+    @Test
+    public void testPlayerIsNotFound() {
+        test("player_is_not_found");
+    }
+
+    /**
+     * Tests params are set as array
+     */
+    @Test
+    public void testFindPlayerWithArrayParams() {
+        test("find_player_array");
+    }
+
+    /**
+     * Tests optional fields
+     */
+    @Test
+    public void testFind() {
+        test("find");
+    }
+
+    /**
+     * Tests overridden method name and response as a list of objects
+     */
+    @Test
+    public void testFindByBirthYear() {
+        test("findByBirthYear");
+    }
+
+    /**
+     * Tests optional fields in array params
+     */
+    @Test
+    public void testFindWithArrayNullParams() {
+        test("find_array_null_params");
+    }
+
+    /**
+     * Tests calling a method from super-class and method without parameters
+     */
+    @Test
+    public void testIsAlive() {
+        test("isAlive");
+    }
+
+    /**
+     * Tests a notification request
+     */
+    @Test
+    public void testNotification() {
+        test("notification");
+    }
+
+    /**
+     * Tests a batch request
+     */
+    @Test
+    public void testBatch() {
+        test("batch");
+    }
+
+    /**
+     * Tests a mixed request
+     */
+    @Test
+    public void testBatchWithNotification() {
+        test("batchWithNotification");
+    }
+
+    /**
+     * Tests passing list as a parameter
+     */
+    @Test
+    public void testFindPlayersByNames() {
+        test("findPlayersByFirstNames");
+    }
+
+    @Test
+    public void testFindPlayersByNumbers() {
+        test("findPlayersByNumbers");
+    }
+
+    @Test
+    public void testGetContractSums() {
+        test("getContractSums");
+    }
+
+    @Test
+    public void testGenericFindPlayersByNumbers() {
+        test("genericFindPlayersByNumbers");
+    }
+
+    private void test(String testName) {
+        try {
+            RequestResponse requestResponse = testData.get(testName);
+            String textRequest = userMapper.writeValueAsString(requestResponse.request());
+            
+            //map here the given test methods to addressed service.
+            textRequest = textRequest.replace("\"method\":\"", "\"method\":\"teamService.");
+
+            String actual = rpcServer.handle(textRequest, serviceResolver);
+            if (!actual.isEmpty()) {
+                assertThat(userMapper.readTree(actual)).isEqualTo(requestResponse.response());
+            } else {
+                assertThat(actual).isEqualTo(requestResponse.response().asText());
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+    
+    // Following tests from SpecTest with mapping to calculatorService
+    private void testCalc(String testName) {
+        try (var is = SpecTest.class.getResourceAsStream("/spec/" + testName + ".properties")) {
+            Properties testProps = new Properties();
+            testProps.load(is);
+            String textRequest = testProps.getProperty("request");
+            
+            //map here the given test methods to addressed service.
+            textRequest = textRequest.replace("\"method\": \"", "\"method\": \"calculatorService.");
+            
+            JsonNode response = userMapper.readTree(testProps.getProperty("response"));
+
+            String actual = rpcServer.handle(textRequest, serviceResolver);
+            if (!actual.isEmpty()) {
+                assertThat(userMapper.readTree(actual)).isEqualTo(response);
+            } else {
+                assertThat(actual).isEqualTo(response.asText());
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Test
+    public void test1() {
+        testCalc("test_1");
+    }
+
+    @Test
+    public void test2() {
+        testCalc("test_2");
+    }
+
+    @Test
+    public void test3() {
+        testCalc("test_3");
+    }
+
+    @Test
+    public void test4() {
+        testCalc("test_4");
+    }
+
+    @Test
+    public void test5() {
+        testCalc("test_5");
+    }
+
+    @Test
+    public void test6() {
+        testCalc("test_6");
+    }
+
+    @Test
+    public void test7() {
+        testCalc("test_7");
+    }
+
+    @Test
+    public void test8() {
+        testCalc("test_8");
+    }
+
+    @Test
+    public void test9() {
+        testCalc("test_9");
+    }
+
+    @Test
+    public void test10() {
+        testCalc("test_10");
+    }
+
+    @Test
+    public void test11() {
+        testCalc("test_11");
+    }
+
+    @Test
+    public void test12() {
+        testCalc("test_12");
+    }
+
+    @Test
+    public void test13() {
+        testCalc("test_13");
+    }
+
+    @Test
+    public void test14() {
+        testCalc("test_14");
+    }
+
+    @Test
+    public void test15() {
+        testCalc("test_15");
+    }
+    
+}


### PR DESCRIPTION
 - The usage of a ServiceResolver in place of a service allows the usage of multiple services, addressed by the request method. E.g. request method "service1.methodA", delegates to service1, calling methodA. request method "service2.methodB", delegates to service2, calling methodB. Using the same JsonRpcServer instance.
 - Custom addressing schemes possible. See tests for single dotted adressing example. 
 - Tests derived from given JsonRpcServerTest in combination with SpecTest, showing simple dot separated addressing scheme.